### PR TITLE
git-issue-28

### DIFF
--- a/reference-iam-keystone-roles.adoc
+++ b/reference-iam-keystone-roles.adoc
@@ -37,7 +37,7 @@ The following table indicates the actions that each Keystone role can perform.
 | View assets  | Yes | Yes 
 | Manage assets | Yes | No
 3+| *Keystone alerts page*: 
-| View alerts | Yes | No 
+| View alerts | Yes | Yes 
 | Manage alerts | Yes | No 
 | Create alerts for self | Yes | Yes
 3+| *Licenses and subscriptions*:


### PR DESCRIPTION
This pull request updates the permissions table in the Keystone roles documentation to clarify alert viewing permissions. The main change ensures that both Admin and User roles are correctly shown as having access to view alerts.

Documentation update:

* In the `reference-iam-keystone-roles.adoc` file, the table was updated so that the "View alerts" action is now marked as "Yes" for both Admin and User roles, instead of just Admin.