### PR TITLE
HOTFIX: Azure permissions correction.

### DIFF
--- a/reference-permissions-azure.adoc
+++ b/reference-permissions-azure.adoc
@@ -188,7 +188,10 @@ The agent makes the following API requests when you use NetApp Data Classificati
 * Microsoft.NetApp/netAppAccounts/capacityPools/volumes/read
 * Microsoft.NetApp/netAppAccounts/capacityPools/volumes/delete
 
-=== Minimal NetApp Backup and Recovery permissions
+=== NetApp Backup and Recovery
+The following sections describe how permissions are used for NetApp Backup and Recovery.
+
+==== Minimal NetApp Backup and Recovery permissions
 
 The Console agent makes the following API requests for basic NetApp Backup and Recovery functionality:
 
@@ -248,7 +251,7 @@ The following is a custom policy for Backup and Recovery that uses the fewest po
 }
 ----
 
-=== Additional Backup and Recovery permissions
+==== Advanced Backup and Recovery permissions
 
 The console agent makes the following API requests for advanced Backup and Recovery operations and Search & Restore features. These permissions enable management of networking, key vaults, and managed identities:
 
@@ -267,9 +270,9 @@ The console agent makes the following API requests for advanced Backup and Recov
 * Microsoft.Resources/deployments/delete
 //end::additional-permissions[]
 
-=== Legacy permissions for Backup and Recovery
+==== Legacy permissions for Backup and Recovery
 
-The agent makes the following API requests when you use the Search & Restore functionality. You only need these permissions if you enabled legacy indexing features before the release of indexing v2:
+The agent makes the following API requests when you use the Search & Restore functionality. You only need these permissions if you enabled legacy indexing features before the release of indexing v2 in February 2025:
 
 //tag::backup-search-restore-permissions[]
 * Microsoft.Synapse/workspaces/write


### PR DESCRIPTION
This pull request reorganizes and clarifies the Azure permissions documentation for Backup and Recovery, separating minimal required permissions from broader permissions, and introducing a new, more restrictive custom policy example. The main changes are the introduction of a minimal custom policy, moving the previous broader policy to a different section, and updating the changelog to reflect these changes.

**Documentation and Policy Organization:**

* Replaced the previous broad "Console Operator" JSON role policy example with a new, minimal custom policy containing only the essential permissions for Backup and Recovery in the main documentation section.
* Added a new section that explicitly documents the minimal custom policy, including its JSON definition and the rationale for its narrow scope.

**Changelog and History Updates:**

* Updated the changelog to note the introduction of the minimal custom policy and removed the detailed list of permissions that were previously part of the broader example.
* Clarified that some permissions were added to the minimal policy, specifically `Microsoft.Authorization/locks/write` and `Microsoft.Authorization/locks/read`.
* Removed the two lock-related permissions from the list of permissions moved to the "Additional Backup and Recovery permissions" section, as they are now included in the minimal set.