### PR TITLE
Updating endpoint list for restricted mode

### DIFF
--- a/_include/endpoints-agent.adoc
+++ b/_include/endpoints-agent.adoc
@@ -165,7 +165,26 @@ Although the previous endpoints are still supported, NetApp recommends updating 
 
 
 
-//end::upgrade-endpoints[]
+//end::upgrade-endpoints-restricted[]
+
+//tag::upgrade-endpoints[]
+a| \https://occmclientinfragov.azurecr.us.io
+\https://bluexpinfraprod.azurecr.io 
+a| To obtain images for Console agent upgrades. 
+
+
+* When you deploy a new agent, the validation check tests connectivity to current endpoints. If you use link:reference-networking-saas-console-previous.html[previous endpoints], the validation check fails. To avoid this failure, skip the validation check.
++
+
+Although the previous endpoints are still supported, NetApp recommends updating your firewall rules to the current endpoints as soon as possible. link:reference-networking-saas-console-previous.html#update-endpoint-list[Learn how to update your endpoint list].
+
+
+
+* When you update to the current endpoints in your firewall, your existing agents will continue to work.
+
+
+
+//end::upgrade-endpoints-restricted[]
 
 //tag::upgrade-endpoints-explanation[]
 

--- a/task-prepare-restricted-mode.adoc
+++ b/task-prepare-restricted-mode.adoc
@@ -72,10 +72,10 @@ Ensure the Console agent has a network connection to the storage locations. For 
 Prepare networking for user access to NetApp Console::
 In restricted mode, users access the Console from the Console agent VM. The Console agent contacts a few endpoints to complete data management tasks. These endpoints are contacted from a user's computer when completing specific actions from the Console.
 
-NOTE: Console agents previous to version 4.0.0 need additional endpoints. If you upgraded to 4.0.0 or later, you can remove the old endpoints from your allow list. link:reference-networking-saas-console-previous.html[Learn more about the required network access for versions previous to 4.0.0.]
+NOTE: Console agents previous to version 4.0.0 support different endpoints. If you upgraded to 4.0.0 or later, you can remove the old endpoints from your allow list. link:reference-networking-saas-console-previous.html[Learn more about the required network access for versions previous to 4.0.0.]
 
 
-+
+
 [cols=2*,options="header,autowidth"]
 
 |===


### PR DESCRIPTION
This pull request updates documentation related to Console agent networking and endpoint requirements, focusing on clarifying instructions for users upgrading to or deploying version 4.0.0 and later. The changes improve guidance on endpoint usage and firewall configuration, and add more explicit instructions for updating to the latest endpoints.

**Documentation improvements for agent networking and endpoints:**

* Updated the note in `task-prepare-restricted-mode.adoc` to clarify that Console agents prior to version 4.0.0 support different endpoints, and that old endpoints can be removed after upgrading.
* Added a new section in `_include/endpoints-agent.adoc` detailing the current endpoints for agent upgrades, instructions for updating firewall rules, and guidance on validation checks when using previous endpoints.