### PR TITLE
Workloads missing endpoint

### DIFF
--- a/reference-networking-saas-console.adoc
+++ b/reference-networking-saas-console.adoc
@@ -83,4 +83,8 @@ a| \https://api.workloads.netapp.com
 
 a| The web-based console contacts this endpoint to interact with the Workload Factory APIs to manage and operate FSx for ONTAP-based workloads.
 
+a| \ws.workloads.bluexp.netapp.com
+
+a| Used by the Workload Factory backend to poll the Console agent for ONTAP operations.
+
 |===

--- a/reference-networking-saas-console.adoc
+++ b/reference-networking-saas-console.adoc
@@ -83,7 +83,7 @@ a| \https://api.workloads.netapp.com
 
 a| The web-based console contacts this endpoint to interact with the Workload Factory APIs to manage and operate FSx for ONTAP-based workloads.
 
-a| \ws.workloads.bluexp.netapp.com
+a| \https://ws.workloads.bluexp.netapp.com
 
 a| Used by the Workload Factory backend to poll the Console agent for ONTAP operations.
 


### PR DESCRIPTION
This pull request adds documentation for a new endpoint used by the Workload Factory backend. The new endpoint is described as being used to poll the Console agent for ONTAP operations.

- **Documentation update:**
  * Added the `https://ws.workloads.bluexp.netapp.com` endpoint to `reference-networking-saas-console.adoc`, including a description of its role in ONTAP operations.