### PR TITLE
4 8 0

### DIFF
--- a/_whatsnew/2026-06-08.adoc
+++ b/_whatsnew/2026-06-08.adoc
@@ -1,0 +1,30 @@
+//All links and images must use the absolute URL.
+
+=== Console agent 4.8.0
+
+The 4.8.0 release supports both standard mode and restricted mode.
+
+This release of the Console agent includes security improvements and bug fixes.
+
+=== NetApp Console administration
+
+This release includes the security improvements and bug fixes.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -21,6 +21,10 @@ Learn what's new with NetApp Console administration features: identity and acces
 
 include::_whatsnew/2026-06-15.adoc[]
 
+== 8 June 2026
+
+include::_whatsnew/2026-06-08.adoc[]
+
 == 11 May 2026
 
 include::_whatsnew/2026-05-11.adoc[]


### PR DESCRIPTION
This pull request updates the release notes for NetApp Console administration by adding a new entry for June 8, 2026. It introduces details about the Console agent 4.8.0 release, highlighting support for both standard and restricted modes, as well as mentioning security improvements and bug fixes.

Release notes updates:

* Added a new section for June 8, 2026, in `whats-new.adoc`, including the `_whatsnew/2026-06-08.adoc` file.
* Created `_whatsnew/2026-06-08.adoc` with information on the Console agent 4.8.0 release, including support for standard and restricted modes, security improvements, and bug fixes.