### PR TITLE
giving actual names for the image for GCP agent deployment

### DIFF
--- a/task-install-agent-google-gcloud.adoc
+++ b/task-install-agent-google-gcloud.adoc
@@ -181,7 +181,7 @@ $ gcloud components update
 [source,bash]
 ----
 
-gcloud compute instances create <instance-name> --machine-type=n2-standard-8 --image-project=<image-project-name> --image-family=<image-family-name> --scopes=cloud-platform --project=<project-name> --service-account="<service-account-name>" --zone=<zone-name> --no-address --tags "<tags>" --network "<network-path>" --subnet "<subnet-path>"
+gcloud compute instances create <instance-name> --machine-type=n2-standard-8 --image-project=netapp-cloudmanager --image-family=cloudmanager --scopes=cloud-platform --project=<project-name> --service-account="<service-account-name>" --zone=<zone-name> --no-address --tags "<tags>" --network "<network-path>" --subnet "<subnet-path>"
 ----
 +
 instance-name:: The desired instance name for the VM instance.


### PR DESCRIPTION
This pull request updates the documentation for creating a Google Cloud VM instance using `gcloud`. The main change is to set default values for the `--image-project` and `--image-family` parameters, which helps users avoid confusion and speeds up the setup process.

**Documentation improvements:**

* Updated the `gcloud compute instances create` command in `task-install-agent-google-gcloud.adoc` to use default values `netapp-cloudmanager` for `--image-project` and `cloudmanager` for `--image-family`, reducing the need for user input and potential errors.