### PR TITLE
Console 4.9.0

### DIFF
--- a/_whatsnew/2026-07-15.adoc
+++ b/_whatsnew/2026-07-15.adoc
@@ -1,0 +1,34 @@
+//All links and images must use the absolute URL.
+
+
+=== Console agent 4.9.0
+
+The 4.9.0 release supports both standard mode and restricted mode.
+
+This release of the Console agent includes security improvements and bug fixes.
+
+=== NetApp Console administration
+
+.Support for role-based access for Cloud Volumes ONTAP 
+You can associate Backup and Recovery workloads (Oracle and Microsoft SQL Server) with projects. After assigning to a project, users who are assigned a Backup and Recovery role for the project can work with the workloads. Other workloads are not supported with role-based access at this time. 
+
+link:https://docs.netapp.com/us-en/data-services-backup-recovery/br-rbac-setup.html[Learn more about setting up role-based access for Backup and Recovery workloads.^]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/_whatsnew/2026-07-15.adoc
+++ b/_whatsnew/2026-07-15.adoc
@@ -10,9 +10,9 @@ This release of the Console agent includes security improvements and bug fixes.
 === NetApp Console administration
 
 .Support for role-based access for Cloud Volumes ONTAP 
-You can associate Backup and Recovery workloads (Oracle and Microsoft SQL Server) with projects. After assigning to a project, users who are assigned a Backup and Recovery role for the project can work with the workloads. Other workloads are not supported with role-based access at this time. 
+Console supports role-based access for Cloud Volumes ONTAP.
 
-link:https://docs.netapp.com/us-en/data-services-backup-recovery/br-rbac-setup.html[Learn more about setting up role-based access for Backup and Recovery workloads.^]
+link:https://docs.netapp.com/us-en/console-setup-admin/reference-iam-cvo-roles.html[Learn more about role-based access for Cloud Volumes ONTAP^].
 
 
 

--- a/project.yml
+++ b/project.yml
@@ -216,6 +216,8 @@ sidebar:
                   entries:
                     - title: Backup and Recovery roles
                       url: /reference-iam-backup-rec-roles.html
+                    - title: Cloud Volumes ONTAP roles
+                      url: /reference-iam-cvo-roles.html
                     - title: Data Classification roles 
                       url: /reference-iam-data-classification.html
                     - title: Disaster Recovery roles

--- a/reference-iam-cvo-roles.adoc
+++ b/reference-iam-cvo-roles.adoc
@@ -19,7 +19,14 @@ Cloud Volumes ONTAP uses the following roles:
 
 * *Cloud Volumes ONTAP admin*: Provides full access to all Cloud Volumes ONTAP operations.
 * *Cloud Volumes ONTAP operator*: Perform important storage operations, such as discovering and managing Cloud Volumes ONTAP systems, including adding volumes, aggregates, snapshots, and replications, modifying some configurations, and upgrading Cloud Volumes ONTAP versions.
-* *Cloud Volumes ONTAP viewer*: View information only, but not perform any operations. Some tabs and screens containing configuration information might be unavailable to viewers.
+* *Cloud Volumes ONTAP viewer*: Provides read-only access to Cloud Volumes ONTAP information. This role can't perform any active operations. Some tabs and screens containing configuration information might be unavailable to viewers.
+
+== How role changes take effect
+
+Cloud Volumes ONTAP enforces role-based access control (RBAC) by using a local cache of each role assignment. The cache refreshes automatically every hour. If a role is newly assigned or changed, it can take up to one hour for the change to take effect. After the refresh completes, the Console enables the workflows permitted by that role.
+
+NOTE: When a Console agent is deployed for the first time, or when an existing Console agent is upgraded to Console 4.9.0 or later, the Console runs a one-time seeding process that assigns Cloud Volumes ONTAP roles to existing users in the organization. This process can take up to 30 minutes to complete.
+
 
 For details about all NetApp Console access roles, see link:reference-iam-predefined-roles.html[access roles].
 
@@ -42,7 +49,7 @@ The following table indicates the actions that each role can perform.
 | Add a system | No | No | Yes
 | Access *Optimized cost and performance* | No | No | Yes
 | Open System Manager | No | No | Yes
-| ##Turn On## | No | No | Yes
+| ##Turn on Cloud Volumes ONTAP## | No | No | Yes
 | Remove a system | No | No | Yes
 
 4+| *Agents page*:

--- a/reference-iam-cvo-roles.adoc
+++ b/reference-iam-cvo-roles.adoc
@@ -5,7 +5,7 @@ keywords: cloud volumes ontap, role-based access control, rbac, viewer, operator
 summary: You can assign the following roles to users to provide them access to Cloud Volumes ONTAP within the Console. Cloud Volumes ONTAP roles give you the flexibility to assign users a role specific to the tasks they need to accomplish within your organization.
 ---
 
-= Cloud Volumes ONTAP access roles for NetApp Console
+= Cloud Volumes ONTAP access roles in NetApp Console
 :hardbreaks:
 :nofooter:
 :icons: font
@@ -17,24 +17,24 @@ You can assign the following roles to users to provide them access to Cloud Volu
 
 Cloud Volumes ONTAP uses the following roles:
 
-* *Cloud Volumes ONTAP admin*: Perform any actions.
-* *Cloud Volumes ONTAP operator*: Discover and manage Cloud Volumes ONTAP working environments, including adding volumes, aggregates, snapshots, and replications, configuring CIFS setup, and upgrading ONTAP.
-* *Cloud Volumes ONTAP viewer*: View information only, but not perform any actions.
+* *Cloud Volumes ONTAP admin*: Provides full access to all Cloud Volumes ONTAP operations.
+* *Cloud Volumes ONTAP operator*: Perform important storage operations, such as discovering and managing Cloud Volumes ONTAP systems, including adding volumes, aggregates, snapshots, and replications, modifying some configurations, and upgrading Cloud Volumes ONTAP versions.
+* *Cloud Volumes ONTAP viewer*: View information only, but not perform any operations. Some tabs and screens containing configuration information might be unavailable to viewers.
 
 For details about all NetApp Console access roles, see link:reference-iam-predefined-roles.html[access roles].
 
 The following table indicates the actions that each role can perform.
 
-[cols="40,20a,20a,20a",options="header",width="100%"]
+[cols="40a,20a,20a,20a",options="header",width="100%"]
 |===
 | Feature and action
 | Cloud Volumes ONTAP viewer
 | Cloud Volumes ONTAP operator
 | Cloud Volumes ONTAP admin
 
-4+| *On the Systems page*:
-| Enter a system | Yes | Yes | Yes
-| View volumes | Yes | Yes | Yes
+4+| *Systems page*:
+| ##Enter a system## | Yes | Yes | Yes
+| View a volume | Yes | Yes | Yes
 | Discover a system | No | Yes | Yes
 | Add a volume | No | Yes | Yes
 | Use *Replication* (not applicable to FSx for ONTAP or on-premises systems) | No | Yes | Yes
@@ -45,11 +45,11 @@ The following table indicates the actions that each role can perform.
 | ##Turn On## | No | No | Yes
 | Remove a system | No | No | Yes
 
-4+| *On the Agents page*:
+4+| *Agents page*:
 | View Cloud Volumes ONTAP settings | Yes | Yes | Yes
 | Edit Cloud Volumes ONTAP settings | No | No | Yes
 
-4+| *On the Overview tab*:
+4+| *Overview tab*:
 | Add a volume | No | Yes | Yes
 | Add an aggregate | No | Yes | Yes
 | Use *Upgrade now* | No | Yes | Yes
@@ -60,9 +60,19 @@ The following table indicates the actions that each role can perform.
 | Set a password | No | No | Yes
 | Remove the system from the workspace | No | No | Yes
 | Delete the system | No | No | Yes
-| Edit *System tags*, *Scheduled downtime*, *Storage classes*, *Instance type*, *Charging method*, *Write speed*, *Ransomware protection*, *Support registration*, and *WORM* from the pencil menu | No | No | Yes
+| Edit the following using the pencil icon on the right pane:
 
-4+| *On the Volumes tab*:
+* *System tags*
+* *Scheduled downtime*
+* *Storage classes*
+* *Instance type*
+* *Charging method*
+* *Write speed*
+* *Ransomware protection*
+* *Support registration*
+* *WORM* | No | No | Yes
+
+4+| *Volumes tab*:
 | Add a volume | No | Yes | Yes
 | Clone a volume | No | Yes | Yes
 | Create a snapshot copy | No | Yes | Yes
@@ -72,13 +82,13 @@ The following table indicates the actions that each role can perform.
 | Change the disk type | No | No | Yes
 | Change the tiering policy | No | No | Yes
 
-4+| *On the Aggregates tab*:
+4+| *Aggregates tab*:
 | Add an aggregate | No | Yes | Yes
 | Add a volume | No | Yes | Yes
 | Increase capacity | No | No | Yes
 | Delete an aggregate | No | No | Yes
 
-4+| *On the Replication page* (with Cloud Volumes ONTAP as the source or destination):
+4+| *Replication page* (with Cloud Volumes ONTAP as the source or destination):
 | Break replication | No | No | Yes
 | Resync replication | No | No | Yes
 | Reverse resync replication | No | No | Yes

--- a/reference-iam-cvo-roles.adoc
+++ b/reference-iam-cvo-roles.adoc
@@ -40,7 +40,7 @@ The following table indicates the actions that each role can perform.
 | Cloud Volumes ONTAP admin
 
 4+| *Systems page*:
-| ##Enter a system## | Yes | Yes | Yes
+| Enter a system| Yes | Yes | Yes
 | View a volume | Yes | Yes | Yes
 | Discover a system | No | Yes | Yes
 | Add a volume | No | Yes | Yes
@@ -49,7 +49,7 @@ The following table indicates the actions that each role can perform.
 | Add a system | No | No | Yes
 | Access *Optimized cost and performance* | No | No | Yes
 | Open System Manager | No | No | Yes
-| ##Turn on Cloud Volumes ONTAP## | No | No | Yes
+| Turn on Cloud Volumes ONTAP | No | No | Yes
 | Remove a system | No | No | Yes
 
 4+| *Agents page*:

--- a/reference-iam-cvo-roles.adoc
+++ b/reference-iam-cvo-roles.adoc
@@ -1,0 +1,90 @@
+---
+sidebar: sidebar
+permalink: reference-iam-cvo-roles.html
+keywords: cloud volumes ontap, role-based access control, rbac, viewer, operator, admin, access control, permissions, volumes, aggregates, replication, snapshots, ontap upgrade, IAM roles
+summary: You can assign the following roles to users to provide them access to Cloud Volumes ONTAP within the Console. Cloud Volumes ONTAP roles give you the flexibility to assign users a role specific to the tasks they need to accomplish within your organization.
+---
+
+= Cloud Volumes ONTAP access roles for NetApp Console
+:hardbreaks:
+:nofooter:
+:icons: font
+:linkattrs:
+:imagesdir: ./media/
+
+[.lead]
+You can assign the following roles to users to provide them access to Cloud Volumes ONTAP within the Console. Cloud Volumes ONTAP roles give you the flexibility to assign users a role specific to the tasks they need to accomplish within your organization. How you assign roles depends on your own business and storage management practices.
+
+Cloud Volumes ONTAP uses the following roles:
+
+* *Cloud Volumes ONTAP admin*: Perform any actions.
+* *Cloud Volumes ONTAP operator*: Discover and manage Cloud Volumes ONTAP working environments, including adding volumes, aggregates, snapshots, and replications, configuring CIFS setup, and upgrading ONTAP.
+* *Cloud Volumes ONTAP viewer*: View information only, but not perform any actions.
+
+For details about all NetApp Console access roles, see link:reference-iam-predefined-roles.html[access roles].
+
+The following table indicates the actions that each role can perform.
+
+[cols="40,20a,20a,20a",options="header",width="100%"]
+|===
+| Feature and action
+| Cloud Volumes ONTAP viewer
+| Cloud Volumes ONTAP operator
+| Cloud Volumes ONTAP admin
+
+4+| *On the Systems page*:
+| Enter a system | Yes | Yes | Yes
+| View volumes | Yes | Yes | Yes
+| Discover a system | No | Yes | Yes
+| Add a volume | No | Yes | Yes
+| Use *Replication* (not applicable to FSx for ONTAP or on-premises systems) | No | Yes | Yes
+| Use drag-and-drop for *Replication* (with Cloud Volumes ONTAP as the source or destination) | No | Yes | Yes
+| Add a system | No | No | Yes
+| Access *Optimized cost and performance* | No | No | Yes
+| Open System Manager | No | No | Yes
+| ##Turn On## | No | No | Yes
+| Remove a system | No | No | Yes
+
+4+| *On the Agents page*:
+| View Cloud Volumes ONTAP settings | Yes | Yes | Yes
+| Edit Cloud Volumes ONTAP settings | No | No | Yes
+
+4+| *On the Overview tab*:
+| Add a volume | No | Yes | Yes
+| Add an aggregate | No | Yes | Yes
+| Use *Upgrade now* | No | Yes | Yes
+| Update the ONTAP version | No | Yes | Yes
+| Edit *CIFS setup* from the pencil menu | No | Yes | Yes
+| Open System Manager | No | No | Yes
+| Use the On/Off button | No | No | Yes
+| Set a password | No | No | Yes
+| Remove the system from the workspace | No | No | Yes
+| Delete the system | No | No | Yes
+| Edit *System tags*, *Scheduled downtime*, *Storage classes*, *Instance type*, *Charging method*, *Write speed*, *Ransomware protection*, *Support registration*, and *WORM* from the pencil menu | No | No | Yes
+
+4+| *On the Volumes tab*:
+| Add a volume | No | Yes | Yes
+| Clone a volume | No | Yes | Yes
+| Create a snapshot copy | No | Yes | Yes
+| Edit volume settings | No | No | Yes
+| Delete a volume | No | No | Yes
+| Restore from a snapshot copy | No | No | Yes
+| Change the disk type | No | No | Yes
+| Change the tiering policy | No | No | Yes
+
+4+| *On the Aggregates tab*:
+| Add an aggregate | No | Yes | Yes
+| Add a volume | No | Yes | Yes
+| Increase capacity | No | No | Yes
+| Delete an aggregate | No | No | Yes
+
+4+| *On the Replication page* (with Cloud Volumes ONTAP as the source or destination):
+| Break replication | No | No | Yes
+| Resync replication | No | No | Yes
+| Reverse resync replication | No | No | Yes
+| Edit the schedule | No | No | Yes
+| Edit the maximum transfer rate | No | No | Yes
+| Update replication | No | No | Yes
+| Delete replication | No | No | Yes
+
+|===

--- a/reference-iam-cvo-roles.adoc
+++ b/reference-iam-cvo-roles.adoc
@@ -21,6 +21,8 @@ Cloud Volumes ONTAP uses the following roles:
 * *Cloud Volumes ONTAP operator*: Perform important storage operations, such as discovering and managing Cloud Volumes ONTAP systems, including adding volumes, aggregates, snapshots, and replications, modifying some configurations, and upgrading Cloud Volumes ONTAP versions.
 * *Cloud Volumes ONTAP viewer*: Provides read-only access to Cloud Volumes ONTAP information. This role can't perform any active operations. Some tabs and screens containing configuration information might be unavailable to viewers.
 
+For details about all NetApp Console access roles, see link:reference-iam-predefined-roles.html[access roles].
+
 == How role changes take effect
 
 Cloud Volumes ONTAP enforces role-based access control (RBAC) by using a local cache of each role assignment. The cache refreshes automatically every hour. If a role is newly assigned or changed, it can take up to one hour for the change to take effect. After the refresh completes, the Console enables the workflows permitted by that role.
@@ -28,7 +30,7 @@ Cloud Volumes ONTAP enforces role-based access control (RBAC) by using a local c
 NOTE: When a Console agent is deployed for the first time, or when an existing Console agent is upgraded to Console 4.9.0 or later, the Console runs a one-time seeding process that assigns Cloud Volumes ONTAP roles to existing users in the organization. This process can take up to 30 minutes to complete.
 
 
-For details about all NetApp Console access roles, see link:reference-iam-predefined-roles.html[access roles].
+== Cloud Volumes ONTAP role permissions
 
 The following table indicates the actions that each role can perform.
 

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -97,9 +97,9 @@ The following is a list of roles in the data service category. Each role grants 
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery restore admin] | RESTORE_ADMIN | Standard, Restricted, Private | Restore workloads in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery clone admin] | CLONE_ADMIN | Standard, Restricted, Private | Clone applications and data in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery viewer] | BACKUP_VIEWER | Standard, Restricted, Private | View Backup and Recovery information.
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] |CVO_ADMIN| Standard, Restricted, Private | ##Provides full access to all Cloud Volumes ONTAP operations.##
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] |CVO_OPERATOR | Standard, Restricted, Private | ##Enables day-to-day management tasks, including adding volumes, configuring replication, and managing storage.##
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] |CVO_VIEWER| Standard, Restricted, Private | ##Provides read-only access to Cloud Volumes ONTAP information. This role can't perform any active operations.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] |CVO_ADMIN| Standard, Restricted, Private | Provides full access to all Cloud Volumes ONTAP operations.
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] |CVO_OPERATOR | Standard, Restricted, Private | Enables day-to-day management tasks, including adding volumes, configuring replication, and managing storage.
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] |CVO_VIEWER| Standard, Restricted, Private | Provides read-only access to Cloud Volumes ONTAP information. This role can't perform any active operations.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery admin] | DISASTER_RECOVERY_ADMIN | Standard | Perform any actions in NetApp Disaster Recovery service.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery failover admin] | DISASTER_RECOVERY_FAILOVER_ADMIN | Standard | Perform failover and migrations.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery application admin] | DISASTER_RECOVERY_APPLICATION_ADMIN | Standard | Create replication plans, change replication plans, and start test failovers.

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -97,9 +97,9 @@ The following is a list of roles in the data service category. Each role grants 
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery restore admin] | RESTORE_ADMIN | Standard, Restricted, Private | Restore workloads in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery clone admin] | CLONE_ADMIN | Standard, Restricted, Private | Clone applications and data in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery viewer] | BACKUP_VIEWER | Standard, Restricted, Private | View Backup and Recovery information.
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] | | Standard, Restricted, Private | ##Perform any actions in Cloud Volumes ONTAP.##
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] | | Standard, Restricted, Private | ##Discover and manage Cloud Volumes ONTAP working environments, including adding volumes, aggregates, snapshots, and replications, configuring CIFS setup, and upgrading ONTAP.##
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] | | Standard, Restricted, Private | ##View Cloud Volumes ONTAP information only.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] |CVO_ADMIN| Standard, Restricted, Private | ##Provides full access to all Cloud Volumes ONTAP operations.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] |CVO_OPERATOR | Standard, Restricted, Private | ##Enables day-to-day management tasks, including adding volumes, configuring replication, and managing storage.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] |CVO_VIEWER| Standard, Restricted, Private | ##View Cloud Volumes ONTAP information only, but not perform any operations.##
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery admin] | DISASTER_RECOVERY_ADMIN | Standard | Perform any actions in NetApp Disaster Recovery service.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery failover admin] | DISASTER_RECOVERY_FAILOVER_ADMIN | Standard | Perform failover and migrations.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery application admin] | DISASTER_RECOVERY_APPLICATION_ADMIN | Standard | Create replication plans, change replication plans, and start test failovers.

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -99,7 +99,7 @@ The following is a list of roles in the data service category. Each role grants 
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery viewer] | BACKUP_VIEWER | Standard, Restricted, Private | View Backup and Recovery information.
 | link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] |CVO_ADMIN| Standard, Restricted, Private | ##Provides full access to all Cloud Volumes ONTAP operations.##
 | link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] |CVO_OPERATOR | Standard, Restricted, Private | ##Enables day-to-day management tasks, including adding volumes, configuring replication, and managing storage.##
-| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] |CVO_VIEWER| Standard, Restricted, Private | ##View Cloud Volumes ONTAP information only, but not perform any operations.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] |CVO_VIEWER| Standard, Restricted, Private | ##Provides read-only access to Cloud Volumes ONTAP information. This role can't perform any active operations.##
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery admin] | DISASTER_RECOVERY_ADMIN | Standard | Perform any actions in NetApp Disaster Recovery service.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery failover admin] | DISASTER_RECOVERY_FAILOVER_ADMIN | Standard | Perform failover and migrations.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery application admin] | DISASTER_RECOVERY_APPLICATION_ADMIN | Standard | Create replication plans, change replication plans, and start test failovers.

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -97,6 +97,9 @@ The following is a list of roles in the data service category. Each role grants 
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery restore admin] | RESTORE_ADMIN | Standard, Restricted, Private | Restore workloads in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery clone admin] | CLONE_ADMIN | Standard, Restricted, Private | Clone applications and data in the Backup and Recovery.
 | link:reference-iam-backup-rec-roles.html[Backup and Recovery viewer] | BACKUP_VIEWER | Standard, Restricted, Private | View Backup and Recovery information.
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP admin] | | Standard, Restricted, Private | ##Perform any actions in Cloud Volumes ONTAP.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP operator] | | Standard, Restricted, Private | ##Discover and manage Cloud Volumes ONTAP working environments, including adding volumes, aggregates, snapshots, and replications, configuring CIFS setup, and upgrading ONTAP.##
+| link:reference-iam-cvo-roles.html[Cloud Volumes ONTAP viewer] | | Standard, Restricted, Private | ##View Cloud Volumes ONTAP information only.##
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery admin] | DISASTER_RECOVERY_ADMIN | Standard | Perform any actions in NetApp Disaster Recovery service.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery failover admin] | DISASTER_RECOVERY_FAILOVER_ADMIN | Standard | Perform failover and migrations.
 | link:reference-iam-disaster-rec-roles.html[Disaster Recovery application admin] | DISASTER_RECOVERY_APPLICATION_ADMIN | Standard | Create replication plans, change replication plans, and start test failovers.

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -17,6 +17,10 @@ Learn what's new with NetApp Console administration features: identity and acces
 
 //All links and images must use the absolute URL.
 
+== 15 July 2026
+
+include::_whatsnew/2026-07-15.adoc[]
+
 == 15 June 2026
 
 include::_whatsnew/2026-06-15.adoc[]


### PR DESCRIPTION
This pull request introduces support for role-based access control (RBAC) for Cloud Volumes ONTAP in the NetApp Console. It documents the new roles, their permissions, and updates the user guide and navigation to reflect these changes. Additionally, it includes a minor improvement to the agent installation instructions.

**Cloud Volumes ONTAP Role-Based Access Control:**

* Added a new documentation page, `reference-iam-cvo-roles.adoc`, detailing Cloud Volumes ONTAP roles (admin, operator, viewer), their permissions, and RBAC behavior in the Console.
* Updated the predefined roles table in `reference-iam-predefined-roles.adoc` to include Cloud Volumes ONTAP admin, operator, and viewer roles, with descriptions and links to the new documentation.
* Updated the sidebar navigation in `project.yml` to add "Cloud Volumes ONTAP roles" under the IAM roles section.
* Added a new "What's New" entry for 15 July 2026, summarizing the Console agent 4.9.0 release and the addition of role-based access for Cloud Volumes ONTAP. [[1]](diffhunk://#diff-b55986eca97ed24f1eff7d53fb864c8adcfe1ee34338866b3fac6abf8563a6cbR1-R34) [[2]](diffhunk://#diff-48c20d0c197b67df2ca82e007a452fe1a1322654b4be4306665dba10419a2242R20-R23)

**Other improvements:**

* Updated the sample `gcloud compute instances create` command in `task-install-agent-google-gcloud.adoc` to use the correct image project and family for NetApp Cloud Manager.