### PR TITLE
Bluexpdoc 1360 hot fix

### DIFF
--- a/_include/endpoints-agent.adoc
+++ b/_include/endpoints-agent.adoc
@@ -89,7 +89,7 @@ The endpoints listed below are all CNAME entries.
 \https://netapp-cloud-account.auth0.com
 \https://netapp-cloud-account.us.auth0.com
 \https://console.netapp.com
-\https://components.console.netapp.com
+\https://components.console.bluexp.netapp.com
 \https://cdn.auth0.com
 | To provide features and services within the NetApp Console.
 
@@ -214,7 +214,7 @@ a|
 * \https://netapp-cloud-account.auth0.com
 * \https://netapp-cloud-account.us.auth0.com
 * \https://console.netapp.com
-* \https://components.console.netapp.com
+* \https://components.console.bluexp.netapp.com
 * \https://cdn.auth0.com
 a| For day-to-day operations.
 a|

--- a/_include/podman-docker-private-mode.adoc
+++ b/_include/podman-docker-private-mode.adoc
@@ -1,0 +1,175 @@
+Depending on your operating system, either Podman or Docker Engine is required before installing the agent.
+
+* Podman is required for Red Hat Enterprise Linux 8 and 9.
++
+<<podman-versions,View the supported Podman versions>>.
+
+* Docker Engine is required for Ubuntu.
++
+<<podman-versions,View the supported Docker Engine versions>>.
+
+.Steps
+
+// start tabbed area
+
+[role="tabbed-block"]
+
+====
+
+.Podman
+
+--
+
+Follow these steps to install and configure Podman:
+
+* Enable and start the podman.socket service
+* Install python3
+* Install the podman-compose package (varies by Red Hat version)
+* Add podman-compose to the PATH environment variable
+* If using Red Hat Enterprise Linux, verify that your Podman version is using Netavark Aardvark DNS instead of CNI
+
+NOTE: Adjust the aardvark-dns port (default: 53) after installing the agent to avoid DNS port conflicts. Follow the instructions to configure the port.
+
+.Steps
+
+. Remove the podman-docker package if it's installed on the host.
++
+[source,cli]
+----
+dnf remove podman-docker
+rm /var/run/docker.sock
+----
+. Install Podman.
++
+You can obtain Podman from official Red Hat Enterprise Linux repositories.
+
+
+.. For Red Hat Enterprise Linux 9.1 to 9.4:
++
+[source,cli]
+----
+sudo dnf install podman-4:<version>
+----
++
+Where <version> is the supported version of Podman that you're installing. <<podman-versions,View the supported Podman versions>>.
+
+.. For Red Hat Enterprise Linux 8:
++
+[source,cli]
+----
+sudo dnf install podman-4:<version>
+----
++
+Where <version> is the supported version of Podman that you're installing. <<podman-versions,View the supported Podman versions>>.
+
+. Enable and start the podman.socket service.
++
+[source,cli]
+----
+sudo systemctl enable --now podman.socket
+----
+. Install python3.
++
+[source,cli]
+----
+sudo dnf install python3
+----
+. Install the EPEL repository package if it's not already available on your system.
+
++
+
+This step is required because podman-compose is available from the Extra Packages for Enterprise Linux (EPEL) repository.
+
+. If using Red Hat Enterprise 9:
+
+.. Install the EPEL repository package.
+
+
++
+
+[source,cli]
+----
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+----
+
+
+
+.. Install podman-compose package 1.5.0. 
++
+[source,cli]
+----
+sudo dnf install podman-compose-1.5.0
+----
+
+
+. If using Red Hat Enterprise Linux 8:
+.. Install the EPEL repository package.
++
+[source,cli]
+----
+sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+----
+.. Install podman-compose package 1.0.6. 
++
+[source,cli]
+----
+sudo dnf install podman-compose-1.0.6
+----
++
+NOTE: Using the `dnf install` command meets the requirement for adding podman-compose to the PATH environment variable. The installation command adds podman-compose to /usr/bin, which is already included in the `secure_path` option on the host.
+
+.. If using Red Hat Enterprise Linux 8, verify that your Podman version is using NetAvark with Aardvark DNS instead of CNI.
+
+... Check to see if your networkBackend is set to CNI by running the following command:
++
+[source,cli]
+----
+podman info | grep networkBackend
+----
+... If the networkBackend is set to `CNI`, you'll need to change it to `netavark`.
+
+... Install `netavark` and `aardvark-dns` using the following command:
++
+[source,cli]
+----
+dnf install aardvark-dns netavark
+----
+... Open the `/etc/containers/containers.conf` file and modify the network_backend option to use "netavark" instead of "cni".
++ 
+If `/etc/containers/containers.conf` doesn't exist, make the configuration changes to `/usr/share/containers/containers.conf`.
+
+... Restart podman.
++
+[source,cli]
+----
+systemctl restart podman
+----
+... Confirm networkBackend is now changed to "netavark" using the following command:
++
+[source,cli]
+----
+podman info | grep networkBackend
+----
+--
+
+.Docker Engine
+--
+Follow the documentation from Docker to install Docker Engine.
+
+.Steps
+
+. https://docs.docker.com/engine/install/[View installation instructions from Docker^]
++
+Follow the steps to install a supported Docker Engine version. Do not install the latest version, as it is unsupported by the Console.
+
+. Verify that Docker is enabled and running.
++
+[source,cli]
+----
+sudo systemctl enable docker && sudo systemctl start docker
+----
+--
+
+====
+
+// end tabbed area

--- a/_whatsnew/2026-07-15.adoc
+++ b/_whatsnew/2026-07-15.adoc
@@ -9,6 +9,8 @@ This release of the Console agent includes security improvements and bug fixes.
 
 === NetApp Console administration
 
+NetApp Console 4.9.0 administration includes the following new feature.
+
 .Support for role-based access for Cloud Volumes ONTAP 
 Console supports role-based access for Cloud Volumes ONTAP.
 

--- a/task-prepare-private-mode.adoc
+++ b/task-prepare-private-mode.adoc
@@ -53,7 +53,7 @@ include::_include/os-reqs.adoc[tag=disk-space]
 
 You need to prepare the host for the Console agent by installing Podman or Docker Engine.
 
-include::_include/podman-docker.adoc[]
+include::_include/podman-docker-private-mode.adoc[]
 
 == Step 5: Prepare networking
 


### PR DESCRIPTION
This pull request updates the documentation to clarify and improve the installation instructions for the Console agent, especially for environments using Podman or Docker, and updates endpoint references for improved accuracy. The most important changes are grouped below.

**Documentation improvements for installation:**

* Removed mention of RHEL 9.6 in private mode instructions
* Updated `task-prepare-private-mode.adoc` to include the new Podman/Docker installation instructions by referencing `_include/podman-docker-private-mode.adoc` instead of the previous include.

**Endpoint updates:**

* Updated endpoint references in `_include/endpoints-agent.adoc` to use `components.console.bluexp.netapp.com` instead of `components.console.netapp.com` for improved accuracy and alignment with current infrastructure. [[1]](diffhunk://#diff-543870bef8f1a863878859f5553223b9fbb867ed323583efd0cdbb26bf073b0eL92-R92) [[2]](diffhunk://#diff-543870bef8f1a863878859f5553223b9fbb867ed323583efd0cdbb26bf073b0eL217-R217)

**Release notes:**

* Added a release note in `_whatsnew/2026-07-15.adoc` announcing support for role-based access for Cloud Volumes ONTAP in NetApp Console 4.9.0 administration.