### PR TITLE
Consistently documenting iam:tagRole

### DIFF
--- a/reference-permissions-aws.adoc
+++ b/reference-permissions-aws.adoc
@@ -370,6 +370,7 @@ For standard regions, the permissions are spread across two policies. Two polici
         "iam:CreateRole",
         "iam:DeleteRole",
         "iam:PutRolePolicy",
+        "iam:TagRole",
         "iam:CreateInstanceProfile",
         "iam:DeleteRolePolicy",
         "iam:AddRoleToInstanceProfile",
@@ -569,6 +570,7 @@ For standard regions, the permissions are spread across two policies. Two polici
         "iam:CreateRole",
         "iam:DeleteRole",
         "iam:PutRolePolicy",
+        "iam:TagRole",
         "iam:CreateInstanceProfile",
         "iam:DeleteRolePolicy",
         "iam:AddRoleToInstanceProfile",
@@ -692,6 +694,7 @@ For standard regions, the permissions are spread across two policies. Two polici
         "iam:CreateRole",
         "iam:DeleteRole",
         "iam:PutRolePolicy",
+        "iam:TagRole",
         "iam:CreateInstanceProfile",
         "iam:DeleteRolePolicy",
         "iam:AddRoleToInstanceProfile",
@@ -962,11 +965,12 @@ The agent makes the following API requests to deploy and manage Cloud Volumes ON
 | Used for daily operations?
 | Used for deletion?
 
-.13+| Create and manage IAM roles and instance profiles for Cloud Volumes ONTAP instances
+.14+| Create and manage IAM roles and instance profiles for Cloud Volumes ONTAP instances
 | iam:ListInstanceProfiles | Yes | Yes | No
 | iam:CreateRole | Yes | No | No
 | iam:DeleteRole | No | Yes | Yes
 | iam:PutRolePolicy | Yes | No | No
+| iam:TagRole | Yes | No | No
 | iam:CreateInstanceProfile | Yes | No | No
 | iam:DeleteRolePolicy | No | Yes | Yes
 | iam:AddRoleToInstanceProfile | Yes | No | No

--- a/reference-permissions-aws.adoc
+++ b/reference-permissions-aws.adoc
@@ -125,6 +125,7 @@ For standard regions, the permissions are spread across two policies. Two polici
         "iam:DeleteInstanceProfile",
         "iam:GetRolePolicy",
         "iam:GetRole",
+        "iam:TagRole",
         "sts:DecodeAuthorizationMessage",
         "sts:AssumeRole",
         "s3:GetBucketTagging",


### PR DESCRIPTION
This pull request updates the AWS permissions documentation to include the `iam:TagRole` permission wherever IAM roles are created or managed. This ensures that the documentation accurately reflects all necessary permissions for managing IAM roles and instance profiles, particularly for tagging roles as part of Cloud Volumes ONTAP operations.

**Documentation updates for IAM role management:**

* Added `iam:TagRole` to all relevant IAM permissions policy lists in `reference-permissions-aws.adoc` to cover tagging of roles during creation and management. [[1]](diffhunk://#diff-a91c5e6cd42b9d516c8194846895b1be2d602b66cc1840e5b4ab7ac036d5ce2bR128) [[2]](diffhunk://#diff-a91c5e6cd42b9d516c8194846895b1be2d602b66cc1840e5b4ab7ac036d5ce2bR373) [[3]](diffhunk://#diff-a91c5e6cd42b9d516c8194846895b1be2d602b66cc1840e5b4ab7ac036d5ce2bR573) [[4]](diffhunk://#diff-a91c5e6cd42b9d516c8194846895b1be2d602b66cc1840e5b4ab7ac036d5ce2bR697)
* Updated the permissions table to include `iam:TagRole` as required for daily operations when managing IAM roles and instance profiles.