### PR TITLE
Release to mention Console local deployment

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -14,6 +14,8 @@ indexpage:
           url: concept-identity-and-access-management.html
         - title: Learn about deployment modes 
           url: concept-modes.html
+        - title: Compare NetApp Console and NetApp Console local deployment
+          url: console-differences.html
     - title: Get started 
       links:
         - title: Getting started with NetApp Console (SaaS)

--- a/concept-modes.adoc
+++ b/concept-modes.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: concept-modes.html
-keywords: dark site, internet, on prem, no internet, supported deployments, govcloud, government access, environments, supported environments, deployment modes, modes, private mode, restricted mode, il6, sc2s, c2s, dark site, sovereign region, saas, government region, secret region, top secret, aws secret, aws top secret, private
+keywords: dark site, internet, on prem, no internet, supported deployments, govcloud, government access, environments, supported environments, deployment modes, modes, private mode, restricted mode, il6, sc2s, c2s, dark site, sovereign region, saas, government region, secret region, top secret, aws secret, aws top secret, private, gove
 summary: You can use NetApp Console through the SaaS application or install it yourself in your own environment (cloud or on-premises). 
 ---
 

--- a/console-differences.adoc
+++ b/console-differences.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: console-differences.html
-keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, active directory, bring-your-own-license, local
+keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, autonomous, active directory, bring-your-own-license, local
 summary: "NetApp Console is a SaaS application that uses Console agents to manage cloud and on-premises storage systems. NetApp Console local deployment is a self-hosted, agentless virtual machine for enterprise-scale ONTAP fleet management with policy enforcement, drift remediation, and full data sovereignty."
 ---
 = Compare NetApp Console and NetApp Console local deployment

--- a/console-differences.adoc
+++ b/console-differences.adoc
@@ -1,10 +1,10 @@
 ---
 sidebar: sidebar
-permalink: intro-family.html
-keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, active directory, bring-your-own-license
+permalink: console-differences.html
+keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, active directory, bring-your-own-license, local
 summary: "NetApp Console is a SaaS application that uses Console agents to manage cloud and on-premises storage systems. NetApp Console local deployment is a self-hosted, agentless virtual machine for enterprise-scale ONTAP fleet management with policy enforcement, drift remediation, and full data sovereignty."
 ---
-= Compare NetApp Console and NetApp Console local deployment
+= Compare NetApp Console local deployment and NetApp Console
 :hardbreaks:
 :nofooter:
 :icons: font

--- a/console-differences.adoc
+++ b/console-differences.adoc
@@ -1,0 +1,15 @@
+---
+sidebar: sidebar
+permalink: intro-family.html
+keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, active directory, bring-your-own-license
+summary: "NetApp Console is a SaaS application that uses Console agents to manage cloud and on-premises storage systems. NetApp Console local deployment is a self-hosted, agentless virtual machine for enterprise-scale ONTAP fleet management with policy enforcement, drift remediation, and full data sovereignty."
+---
+= Compare NetApp Console and NetApp Console local deployment
+:hardbreaks:
+:nofooter:
+:icons: font
+:linkattrs:
+:imagesdir: ./media/
+:allow-uri-read:
+
+include::https://raw.githubusercontent.com/NetAppDocs/console-all-family/main/intro-family.adoc[lines=15..-1]

--- a/console-differences.adoc
+++ b/console-differences.adoc
@@ -4,7 +4,7 @@ permalink: console-differences.html
 keywords: netapp console, netapp console local deployment, comparison, saas, self-hosted, deployment modes, on-premises, cloud, storage management, data sovereignty, agentless, ONTAP fleet management, policy enforcement, storage class policies, data residency, vCenter, fleet management, workload analyzer, identity federation, active directory, bring-your-own-license, local
 summary: "NetApp Console is a SaaS application that uses Console agents to manage cloud and on-premises storage systems. NetApp Console local deployment is a self-hosted, agentless virtual machine for enterprise-scale ONTAP fleet management with policy enforcement, drift remediation, and full data sovereignty."
 ---
-= Compare NetApp Console local deployment and NetApp Console
+= Compare NetApp Console and NetApp Console local deployment
 :hardbreaks:
 :nofooter:
 :icons: font

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,8 @@ sidebar:
           url: /whats-new.html
         - title: Known limitations
           url: /reference-limitations.html
+        - title: Compare NetApp Console and NetApp Console local deployment
+          url: /console-differences.html
     - title: Get started
       entries:
         - title: Learn the basics


### PR DESCRIPTION
This pull request introduces a new comparison page for NetApp Console deployment options and updates navigation to include this resource. The main goal is to help users understand the differences between the SaaS and self-hosted (local) deployment modes. The most important changes are:

**New documentation:**

* Added a new page, `console-differences.adoc`, that compares NetApp Console (SaaS) and NetApp Console local deployment (self-hosted), detailing features, deployment models, and use cases.

**Navigation updates:**

* Updated `_index.yml` to add a navigation link to the new comparison page under the "Learn" section.
* Updated `project.yml` to add the new comparison page to the sidebar for easier access.

**Metadata and SEO improvements:**

* Expanded the `keywords` metadata in `concept-modes.adoc` to include additional terms related to government and deployment modes for better searchability.